### PR TITLE
comment and package cleanup, mainly remove TFA from requirements

### DIFF
--- a/main_vif.py
+++ b/main_vif.py
@@ -2,7 +2,6 @@
 import tensorflow as tf
 tf.executing_eagerly()
 import os
-# os.environ["CUDA_VISIBLE_DEVICES"]="5"
 import numpy as np
 import random
 
@@ -24,9 +23,6 @@ os.environ['TF_CUDNN_DETERMINISTIC'] = '1'
 import argparse
 import datetime
 import time
-import re
-import pandas as pd
-import scipy.io
 # tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
 # import tensorrt
 from scipy import ndimage
@@ -35,7 +31,6 @@ from matplotlib import colors as mcolors
 # from tensorflow.keras import mixed_precision
 import psutil
 import time
-import shutil
 
 # tf.debugging.set_log_device_placement(True)
 os.environ["TF_GPU_THREAD_MODE"] = "gpu_private"

--- a/make_mosaics.py
+++ b/make_mosaics.py
@@ -2,7 +2,6 @@
 import tensorflow as tf
 tf.executing_eagerly()
 import os
-# os.environ["CUDA_VISIBLE_DEVICES"]="6"
 import numpy as np
 import random
 import csv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 cupy>=13.3.0
 matplotlib>=3.10.0
 nibabel>=5.3.2
-nilearn>=0.11.0
 numba>=0.60.0
 numpy>=1.23.5
 pandas>=2.0.0
@@ -12,6 +11,5 @@ psutil>=5.9.5
 scipy>=1.14.1
 tensorboard>=2.12.1
 tensorflow>=2.12.0
-tensorflow_addons>=0.19.0
 tensorrt>=10.4.0
 tensorrt_cu12>=10.4.0

--- a/tests.py
+++ b/tests.py
@@ -1,10 +1,8 @@
 import unittest
 import numpy as np
 import nibabel as nib
-import time
 import os
 import tensorflow as tf
-import nilearn.plotting as plotting
 from utils_vif import *
 from model_vif import *
 


### PR DESCRIPTION
This pull request primarily cleans up unused imports and commented-out code across several Python files, making the codebase cleaner, easier to maintain, and more compatible with future TF/Python versions. No functional changes are introduced.

Code cleanup and maintenance:

* Removed commented-out `os.environ["CUDA_VISIBLE_DEVICES"]` lines from `main_vif.py` and `make_mosaics.py`. [[1]](diffhunk://#diff-192f6473eb7fb2cb3ef4485752982f601269b30920241086d1ed8b40228d1534L5) [[2]](diffhunk://#diff-6c7b44361df6de9195b4929bbdc307edfa0dd4550ee08da0fdd2b70024fc4313L5)
* Removed unused imports such as `re`, `pandas`, `scipy.io`, `shutil`, `time`, and `nilearn.plotting` from `main_vif.py` and `tests.py`. [[1]](diffhunk://#diff-192f6473eb7fb2cb3ef4485752982f601269b30920241086d1ed8b40228d1534L27-L29) [[2]](diffhunk://#diff-192f6473eb7fb2cb3ef4485752982f601269b30920241086d1ed8b40228d1534L38) [[3]](diffhunk://#diff-f455f302936271d755f6892d443786094d2607b505ff180ca817cb9eeabe1e5eL4-L7)